### PR TITLE
progress toward re-submit capability

### DIFF
--- a/examples/FEISTY_driver.py
+++ b/examples/FEISTY_driver.py
@@ -5,100 +5,419 @@ Script that uses dask to run FEISTY in parallel
 """
 
 import os
+import tempfile
 import time
+from subprocess import check_call
 
+import click
 import dask_mpi
+import numpy as np
 import xarray as xr
 import yaml
 from dask.distributed import Client
+from jinja2 import Template
 
 import feisty
 
-#################
-# Configure Run #
-#################
+path_to_here = os.path.dirname(os.path.realpath(__file__))
+USER = os.environ['USER']
 
-# First thing to do: initialize dask-mpi
-dask_mpi.initialize()
 
-import argparse
+class driver_settings(object):
+    """Class to support curating FEISTY_driver parameters"""
 
-parser = argparse.ArgumentParser(description='Offline driver for FEISTY')
-parser.add_argument(
-    '-f',
-    '--yaml_file',
-    action='store',
-    default='FOSI.yaml',
-    dest='yaml_file',
-    help='YAML file containing configuration settings for FEISTY',
+    def __init__(
+        self,
+        run_config_file,
+        run_forcing_file,
+        run_settings_file=None,
+        continue_run=False,
+    ):
+
+        self.run_config_file = run_config_file
+        self.run_forcing_file = run_forcing_file
+        self.run_settings_file = run_settings_file
+
+        # set run config properties
+        config_info = self._read_file(run_config_file, apply_template=True)
+        forcing_info = self._read_file(run_forcing_file, apply_template=True)
+        self.settings_in = self._read_file(run_settings_file)
+
+        self.run_name = config_info.pop('run_name')
+        self.computing_account = config_info.pop('computing_account')
+        self.run_dir_root = config_info.pop('run_dir_root', '.')
+        self.diagnostic_names = config_info.pop('diagnostic_names', [])
+
+        self.resubmit = config_info.pop('resubmit', False)
+
+        self.forcing_rename = config_info.pop('forcing_rename', {})
+        self.ignore_year_in_forcing = config_info.pop('ignore_year_in_forcing', False)
+        self.max_output_time_dim = config_info.pop('max_output_time_dim', 365)
+        self.method = config_info.pop('method', 'euler')
+        self.num_chunks = config_info.pop('num_chunks', 18)
+        self.output_in_2D = config_info.pop('output_in_2D', True)
+        self.calendar = config_info.pop('calendar', 'noleap')
+
+        if self.calendar != 'noleap':
+            raise NotImplementedError(f'unsupported calendar: {self.calendar}')
+
+        # set ic and forcing properties
+        self.forcing_keys = forcing_info['keys']
+        if continue_run:
+            assert os.path.exists(self.restart_pointer), 'missing restart pointer file'
+
+            restart_info = self._read_file(self.restart_pointer)
+            self.ic_file = restart_info['ic_file']
+
+            assert (
+                restart_info['forcing_key'] in self.forcing_keys
+            ), f"unknown forcing key: {restart_info['forcing_key']} in restart pointer"
+            # increment forcing keys
+            key_ndx = self.forcing_keys.index(self.forcing_key) + 1
+
+        else:
+            self.ic_file = config_info.pop('ic_file', None)
+            key_ndx = 0
+
+        self.forcing_key = self.forcing_keys[key_ndx]
+        self.last_submission = key_ndx >= len(self.forcing_keys) - 1
+
+        forcing_info_key = forcing_info[self.forcing_key]
+        self.start_date = forcing_info_key.pop('start_date')
+        self.nyears = forcing_info_key.pop('nyears')
+        self.list_forcing_files = forcing_info_key.pop('list_forcing_files')
+
+        assert not config_info, f'unknown keys in input file: {config_info}'
+        assert not forcing_info_key, f'unknown keys in forcing file: {forcing_info_key}'
+
+    def write_restart_pointer(self):
+        """write a restart pointer file"""
+        restart_info = {
+            'ic_file': self.restart_file,
+            'forcing_key': self.forcing_key,
+        }
+        with open(self.restart_pointer, 'w') as fid:
+            yaml.dump(restart_info, fid)
+
+    @property
+    def restart_pointer(self):
+        return f'{self.run_dir}/restart-pointer.yml'
+
+    def _read_file(self, filename, apply_template=False):
+        """return dictionary from YAML file"""
+        if filename is None:
+            return {}
+
+        # read parameters from yaml
+        with open(filename, 'r') as f:
+            file_dict_in = yaml.safe_load(f)
+
+        if not apply_template:
+            return file_dict_in
+
+        # apply environment variable templating
+        file_dict = {}
+        for key, value in file_dict_in.items():
+            # what's a better way to check for environment variable
+            # replacement?
+            if isinstance(value, str) and 'env[' in value:
+                file_dict[key] = Template(value).render(env=os.environ)
+            else:
+                file_dict[key] = value
+
+        return file_dict
+
+    @property
+    def nsteps(self):
+        """return number of timesteps"""
+        assert self.nyears is not None, 'nyears not set'
+        if self.calendar == 'noleap':
+            return 365 * self.nyears
+        else:
+            raise ValueError(f'unknown calendar: {self.calendar}')
+
+    @property
+    def end_date(self):
+        return xr.cftime_range(self.start_date, periods=self.nsteps, calendar=self.calendar)[
+            -1
+        ].strftime('%Y-%m-%d')
+
+    @property
+    def file_datestr(self):
+        return f"{self.start_date.replace('-', '')}-{self.end_date.replace('-', '')}"
+
+    @property
+    def run_dir(self):
+        return f'{self.run_dir_root}/{self.run_name}'
+
+    @property
+    def output_file(self):
+        return f'{self.run_dir}/{self.run_name}.{self.file_datestr}.nc'
+
+    @property
+    def restart_file(self):
+        return f'{self.run_dir}/{self.run_name}.restart.{self.end_date}.nc'
+
+    def _file_in_run_dir(self, file):
+        """return a path to a file copied into `run_dir`"""
+        return f'{self.run_dir}/{os.path.basename(file)}'
+
+    def setup_run_dir(self):
+        """ensure that files needed to run the model are in `run_dir`"""
+        os.makedirs(self.run_dir, exist_ok=True)
+        ensure_files = [
+            self.run_config_file,
+            self.run_forcing_file,
+            self.run_settings_file,
+        ]
+        for file in ensure_files:
+            if file is None:
+                continue
+            check_call(['cp', file, self._file_in_run_dir(file)])
+
+
+def gen_jobscript(run_config_file, run_forcing_file, run_settings_file=None, continue_run=False):
+    """return a jobscript file suitable for submission to queue"""
+
+    run_settings = driver_settings(
+        run_config_file,
+        run_forcing_file,
+        run_settings_file,
+        continue_run,
+    )
+
+    mpi_tasks = run_settings.num_chunks + 2
+
+    run_config_file = run_settings.run_config_file
+    run_forcing_file = run_settings.run_forcing_file
+    run_settings_file = run_settings.run_settings_file
+
+    indent_spc = ' ' * 4
+    options = [
+        f'{indent_spc}--run-config-file {run_config_file}',
+        f'--run-forcing-file {run_forcing_file}',
+    ]
+
+    if run_settings.run_settings_file is not None:
+        options.append(f'--run-settings-file {run_settings_file}')
+
+    if continue_run:
+        options.append('--continue-run')
+
+    # options_str = f' \\ \n{indent_spc}'.join(options)
+    options_str = ' '.join(options)
+
+    lines = [
+        '#!/bin/bash -l',
+        f'#PBS -N {run_settings.run_name}',
+        f'#PBS -A {run_settings.computing_account}',
+        f'#PBS -l select=1:ncpus={mpi_tasks}:mpiprocs={mpi_tasks}:mem=360GB',
+        '#PBS -l walltime=06:00:00',
+        '#PBS -q casper',
+        '#PBS -j oe',
+        '#PBS -m abe',
+        '',
+        'source activate dev-feisty',
+        '',
+        f'mpirun -n {mpi_tasks} {path_to_here}/./FEISTY_driver.py {options_str}',
+        '',
+    ]
+
+    _, jobscript = tempfile.mkstemp(prefix='feisty-run.', suffix='.sh', text=True)
+
+    with open(jobscript, 'w') as fid:
+        fid.write('\n'.join(lines))
+
+    return jobscript
+
+
+def submit_run(run_config_file, run_forcing_file, run_settings_file=None, continue_run=False):
+    """submit a FEISTY integration to the queue"""
+
+    run_settings = driver_settings(
+        run_config_file,
+        run_forcing_file,
+        run_settings_file,
+        continue_run,
+    )
+
+    run_settings.setup_run_dir()
+
+    jobscript = gen_jobscript(run_config_file, run_forcing_file, run_settings_file, continue_run)
+
+    print('submitting run')
+    print(f'qsub {jobscript}')
+
+    return check_call(['qsub', jobscript], cwd=run_settings.run_dir)
+
+
+@click.command(help='Offline driver for FEISTY')
+@click.option(
+    '--run-config-file',
+    type=click.Path(exists=True),
+    required=True,
+    help='YAML file containing run settings',
 )
-args = parser.parse_args()
-if not os.path.isfile(args.yaml_file):
-    raise FileNotFoundError(f'"{args.yaml_file}" can not be found')
-
-# read parameters from yaml
-with open(args.yaml_file, 'r') as f:
-    parameters = yaml.safe_load(f)
-
-ds = feisty.utils.generate_single_ds_for_feisty(
-    num_chunks=parameters['num_chunks'],
-    forcing_file=parameters['forcing_file'],
-    ic_file=parameters['ic_file'],
-    forcing_rename=parameters['forcing_rename'],
+@click.option(
+    '--run-forcing-file',
+    type=click.Path(exists=True),
+    required=True,
+    help='YAML file containing forcing data',
 )
-
-print(ds)
-print('\n----\n')
-
-# Generate a template for the output of map_blocks
-template = feisty.utils.generate_template(
-    ds=ds,
-    nsteps=parameters['nyears'] * 365,
-    start_date=parameters['start_date'],
-    diagnostic_names=parameters['diagnostic_names'],
+@click.option(
+    '--run-settings-file',
+    type=click.Path(exists=True),
+    required=False,
+    help='YAML file containing FEISTY model parameters',
 )
+@click.option(
+    '--continue-run',
+    is_flag=True,
+    required=False,
+    help='flag to read initial conditions from restart file',
+)
+def main(
+    run_config_file,
+    run_forcing_file,
+    run_settings_file=None,
+    continue_run=False,
+):
 
-print(template)
-print('\n----\n')
+    # configure Run
+    run_settings = driver_settings(
+        run_config_file,
+        run_forcing_file,
+        run_settings_file,
+        continue_run,
+    )
 
-###############
-# Set up dask #
-###############
+    os.makedirs(run_settings.run_dir, exist_ok=True)
 
-nsteps = 365 * parameters['nyears']
-print(f'Starting compute at {time.strftime("%H:%M:%S")}')
-with Client() as c:
-    # map_blocks lets us run in parallel over our dask cluster
-    ds_out = xr.map_blocks(
-        feisty.config_and_run_from_dataset,
-        ds,
-        args=(
-            nsteps,
-            parameters['start_date'],
-            parameters['ignore_year_in_forcing'],
-            parameters['settings_in'],
-            parameters['diagnostic_names'],
-            parameters['max_output_time_dim'],
-            parameters['method'],
-        ),
-        template=template,
-    ).compute()
-    # if output_file is .zarr, skip compute() and call to_zarr() here
-    # could also write to zarr, then read zarr and write to netcdf
+    # initialize dask-mpi
+    dask_mpi.initialize()
 
-# omit .compute and write to zarr?
-if parameters['output_file']:
-    if os.path.isfile(parameters['output_file']):
-        print(f'{parameters["output_file"]} exists, removing now...')
-        os.remove(parameters['output_file'])
+    print('\n')
+    print('-' * 50)
+    print('generating forcing dataset')
+    print('-' * 50)
 
-    if parameters.get('output_in_2D', False):
-        map_ds = feisty.utils.generate_1D_to_2D_pop_map(parameters['forcing_file'])
+    ds = feisty.utils.generate_single_ds_for_feisty(
+        num_chunks=run_settings.num_chunks,
+        forcing_file=run_settings.list_forcing_files,
+        forcing_rename=run_settings.forcing_rename,
+    ).persist()
+
+    print(ds)
+    print('\n----\n')
+
+    print('\n')
+    print('-' * 50)
+    print('generating IC dataset')
+    print('-' * 50)
+
+    ds_ic = feisty.utils.generate_ic_ds_for_feisty(
+        ds.X.data,
+        ic_file=run_settings.ic_file,
+        num_chunks=run_settings.num_chunks,
+    ).persist()
+
+    print(ds_ic)
+    print('\n----\n')
+
+    # Generate a template for the output of map_blocks
+    print('\n')
+    print('-' * 50)
+    print('generating template dataset')
+    print('-' * 50)
+
+    template = feisty.utils.generate_template(
+        ds=ds,
+        nsteps=run_settings.nsteps,
+        start_date=run_settings.start_date,
+        diagnostic_names=run_settings.diagnostic_names,
+    )
+
+    print(template)
+    print('\n----\n')
+
+    # Run FEISTY
+    print('\n')
+    print('-' * 50)
+    print(f'Starting compute at {time.strftime("%H:%M:%S")}')
+    print('-' * 50)
+
+    with Client():
+        # map_blocks lets us run in parallel over our dask cluster
+        ds_out = xr.map_blocks(
+            feisty.config_and_run_from_dataset,
+            ds,
+            args=(
+                ds_ic,
+                run_settings.nsteps,
+                run_settings.start_date,
+                run_settings.ignore_year_in_forcing,
+                run_settings.settings_in,
+                run_settings.diagnostic_names,
+                run_settings.max_output_time_dim,
+                run_settings.method,
+            ),
+            template=template,
+        ).compute()
+        # if output_file is .zarr, skip compute() and call to_zarr() here
+        # could also write to zarr, then read zarr and write to netcdf
+
+    print('\n')
+    print('-' * 50)
+    print('integration completed')
+    print('-' * 50)
+    print(ds_out)
+    print('\n----\n')
+
+    # omit .compute and write to zarr?
+    if os.path.isfile(run_settings.output_file):
+        print(f'{run_settings.output_file} exists, removing now...')
+        os.remove(run_settings.output_file)
+
+    print('\n')
+    print('-' * 50)
+    print(f'writing output file: {run_settings.output_file}')
+    print('-' * 50)
+    if run_settings.output_in_2D:
+        map_ds = feisty.utils.generate_1D_to_2D_pop_map(run_settings.list_forcing_files)
         ds_out2 = feisty.utils.map_ds_back_to_2D_pop(ds_out, map_ds)
-        ds_out2.to_netcdf(parameters['output_file'])
+        ds_out2.to_netcdf(run_settings.output_file)
     else:
-        ds_out.to_netcdf(parameters['output_file'])
+        ds_out.to_netcdf(run_settings.output_file)
 
-print(f'Finished at {time.strftime("%H:%M:%S")}')
+    print(f'Finished at {time.strftime("%H:%M:%S")}')
+    print('\n----\n')
 
-# dask_mpi.send_close_signal()
+    print('\n')
+    print('-' * 50)
+    print(f'writing restart file: {run_settings.restart_file}')
+    print('-' * 50)
+
+    run_settings.write_restart_pointer()
+    # TODO: better approach here? Can't write X as multi-index to netCDF
+    ds_out['X'] = np.arange(0, len(ds_out.X))
+    ds_out.isel(time=-1).to_netcdf(run_settings.restart_file)
+
+    print('\n----\n')
+
+    # dask_mpi.send_close_signal()
+    if run_settings.resubmit and not run_settings.last_submission:
+        print('resubmitting')
+        submit_run(
+            run_config_file,
+            run_forcing_file,
+            run_settings_file,
+            continue_run=True,
+        )
+    print('\n')
+    print('-' * 50)
+    print('completed')
+    print('-' * 50)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/feisty-config.TL319_g17.4p2z.001.yml
+++ b/examples/feisty-config.TL319_g17.4p2z.001.yml
@@ -1,0 +1,18 @@
+computing_account: P93300670
+diagnostic_names: []
+forcing_rename:
+  HT: bathymetry
+  TEMP_BOTTOM: T_bottom
+  TEMP_mean_100m: T_pelagic
+  mesozooC_zint_100m_2: zooC
+  mesozoo_loss_zint_100m: zoo_mort
+  pocToFloor: poc_flux_bottom
+  time: forcing_time
+ignore_year_in_forcing: false
+max_output_time_dim: 365
+method: euler
+num_chunks: 32
+output_in_2D: true
+resubmit: true
+run_dir_root: /glade/scratch/{{env['USER']}}
+run_name: feisty.TL319_g17.4p2z.001

--- a/examples/feisty-config.TL319_t13.4p2z.001.yml
+++ b/examples/feisty-config.TL319_t13.4p2z.001.yml
@@ -1,0 +1,19 @@
+computing_account: P93300670
+diagnostic_names: []
+forcing_rename:
+  HT: bathymetry
+  TEMP_BOTTOM: T_bottom
+  TEMP_mean_100m: T_pelagic
+  mesozooC_zint_100m_2: zooC
+  mesozoo_loss_zint_100m: zoo_mort
+  pocToFloor: poc_flux_bottom
+  time: forcing_time
+ignore_year_in_forcing: false
+max_output_time_dim: 365
+method: euler
+num_chunks: 32
+output_in_2D: true
+resubmit: true
+run_dir_root: /glade/scratch/{{env['USER']}}
+run_name: feisty.TL319_t13.4p2z.001
+write_output: true

--- a/examples/feisty-forcing.TL319_g17.4p2z.001.yml
+++ b/examples/feisty-forcing.TL319_g17.4p2z.001.yml
@@ -1,0 +1,11 @@
+195801-196712:
+  list_forcing_files:
+    - /glade/work/mlevy/codes/feisty/input_files/1deg_companion_run/g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch.pop.h.TEMP_BOTTOM.195801-196712.nc
+    - /glade/work/mlevy/codes/feisty/input_files/1deg_companion_run/g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch.pop.h.TEMP_mean_100m.195801-196712.nc
+    - /glade/work/mlevy/codes/feisty/input_files/1deg_companion_run/g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch.pop.h.mesozooC_zint_100m_2.195801-196712.nc
+    - /glade/work/mlevy/codes/feisty/input_files/1deg_companion_run/g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch.pop.h.mesozoo_loss_zint_100m.195801-196712.nc
+    - /glade/work/mlevy/codes/feisty/input_files/1deg_companion_run/g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch.pop.h.pocToFloor.195801-196712.nc
+  nyears: 1
+  start_date: '1958-01-01'
+keys:
+  - 195801-196712

--- a/examples/feisty-forcing.TL319_t13.4p2z.001.yml
+++ b/examples/feisty-forcing.TL319_t13.4p2z.001.yml
@@ -1,0 +1,101 @@
+196401-196412:
+  list_forcing_files:
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_BOTTOM.196401-196412.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_mean_100m.196401-196412.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozooC_zint_100m_2.196401-196412.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozoo_loss_zint_100m.196401-196412.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.pocToFloor.196401-196412.nc
+  nyears: 1
+  start_date: '1964-01-01'
+196501-196512:
+  list_forcing_files:
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_BOTTOM.196501-196512.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_mean_100m.196501-196512.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozooC_zint_100m_2.196501-196512.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozoo_loss_zint_100m.196501-196512.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.pocToFloor.196501-196512.nc
+  nyears: 1
+  start_date: '1965-01-01'
+196601-196612:
+  list_forcing_files:
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_BOTTOM.196601-196612.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_mean_100m.196601-196612.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozooC_zint_100m_2.196601-196612.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozoo_loss_zint_100m.196601-196612.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.pocToFloor.196601-196612.nc
+  nyears: 1
+  start_date: '1966-01-01'
+196701-196712:
+  list_forcing_files:
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_BOTTOM.196701-196712.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_mean_100m.196701-196712.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozooC_zint_100m_2.196701-196712.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozoo_loss_zint_100m.196701-196712.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.pocToFloor.196701-196712.nc
+  nyears: 1
+  start_date: '1967-01-01'
+196801-196812:
+  list_forcing_files:
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_BOTTOM.196801-196812.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_mean_100m.196801-196812.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozooC_zint_100m_2.196801-196812.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozoo_loss_zint_100m.196801-196812.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.pocToFloor.196801-196812.nc
+  nyears: 1
+  start_date: '1968-01-01'
+196901-196912:
+  list_forcing_files:
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_BOTTOM.196901-196912.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_mean_100m.196901-196912.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozooC_zint_100m_2.196901-196912.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozoo_loss_zint_100m.196901-196912.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.pocToFloor.196901-196912.nc
+  nyears: 1
+  start_date: '1969-01-01'
+197001-197012:
+  list_forcing_files:
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_BOTTOM.197001-197012.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_mean_100m.197001-197012.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozooC_zint_100m_2.197001-197012.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozoo_loss_zint_100m.197001-197012.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.pocToFloor.197001-197012.nc
+  nyears: 1
+  start_date: '1970-01-01'
+197101-197112:
+  list_forcing_files:
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_BOTTOM.197101-197112.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_mean_100m.197101-197112.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozooC_zint_100m_2.197101-197112.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozoo_loss_zint_100m.197101-197112.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.pocToFloor.197101-197112.nc
+  nyears: 1
+  start_date: '1971-01-01'
+197201-197212:
+  list_forcing_files:
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_BOTTOM.197201-197212.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_mean_100m.197201-197212.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozooC_zint_100m_2.197201-197212.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozoo_loss_zint_100m.197201-197212.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.pocToFloor.197201-197212.nc
+  nyears: 1
+  start_date: '1972-01-01'
+197301-197312:
+  list_forcing_files:
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_BOTTOM.197301-197312.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.TEMP_mean_100m.197301-197312.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozooC_zint_100m_2.197301-197312.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.mesozoo_loss_zint_100m.197301-197312.nc
+    - /glade/scratch/kristenk/hi-res-feisty-inputs/g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001.pop.h.pocToFloor.197301-197312.nc
+  nyears: 1
+  start_date: '1973-01-01'
+keys:
+  - 196401-196412
+  - 196501-196512
+  - 196601-196612
+  - 196701-196712
+  - 196801-196812
+  - 196901-196912
+  - 197001-197012
+  - 197101-197112
+  - 197201-197212
+  - 197301-197312

--- a/examples/feisty-settings.TL319_g17.4p2z.001.yml
+++ b/examples/feisty-settings.TL319_g17.4p2z.001.yml
@@ -1,0 +1,196 @@
+benthic_prey:
+  defaults:
+    benthic_efficiency: 0.075
+    carrying_capacity: 80.0
+  members:
+    - name: benthic_prey
+fish:
+  defaults:
+    a_consumption: 20.0
+    a_encounter: 70.0
+    a_metabolism: 4.0
+    assim_efficiency: 0.7
+    b_consumption: 0.25
+    b_encounter: 0.2
+    b_metabolism: 0.175
+    k_consumption: 0.063
+    k_encounter: 0.063
+    k_metabolism: 0.0855
+    mortality_coeff_per_yr: 0.1
+    mortality_type: constant
+  members:
+    - energy_frac_somatic_growth: 1.0
+      functional_type: forage
+      harvest_selectivity: 0.0
+      name: Sf
+      pelagic_demersal_coupling: false
+      size_class: small
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 1.0
+      functional_type: piscivore
+      harvest_selectivity: 0.0
+      name: Sp
+      pelagic_demersal_coupling: false
+      size_class: small
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 1.0
+      functional_type: demersal
+      harvest_selectivity: 0.0
+      name: Sd
+      pelagic_demersal_coupling: false
+      size_class: small
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 0.5
+      functional_type: forage
+      harvest_selectivity: 1.0
+      name: Mf
+      pelagic_demersal_coupling: false
+      size_class: medium
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 1.0
+      functional_type: piscivore
+      harvest_selectivity: 0.1
+      name: Mp
+      pelagic_demersal_coupling: false
+      size_class: medium
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 1.0
+      functional_type: demersal
+      harvest_selectivity: 0.1
+      name: Md
+      pelagic_demersal_coupling: false
+      size_class: medium
+      t_frac_pelagic_static: 0.0
+    - energy_frac_somatic_growth: 0.5
+      functional_type: piscivore
+      harvest_selectivity: 1.0
+      name: Lp
+      pelagic_demersal_coupling: false
+      size_class: large
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 0.5
+      functional_type: demersal
+      harvest_selectivity: 1.0
+      name: Ld
+      pelagic_demersal_coupling: true
+      size_class: large
+      t_frac_pelagic_static: 0.0
+fishing:
+  fishing_rate_per_year: 0.3
+food_web:
+  - predator: Sf
+    preference: 0.9
+    prey: Zoo
+  - predator: Sp
+    preference: 0.9
+    prey: Zoo
+  - predator: Sd
+    preference: 0.9
+    prey: Zoo
+  - predator: Mf
+    preference: 0.45
+    prey: Zoo
+  - predator: Mf
+    preference: 1.0
+    prey: Sf
+  - predator: Mf
+    preference: 1.0
+    prey: Sp
+  - predator: Mf
+    preference: 1.0
+    prey: Sd
+  - predator: Mp
+    preference: 0.45
+    prey: Zoo
+  - predator: Mp
+    preference: 1.0
+    prey: Sf
+  - predator: Mp
+    preference: 1.0
+    prey: Sp
+  - predator: Mp
+    preference: 1.0
+    prey: Sd
+  - predator: Md
+    preference: 1.0
+    prey: benthic_prey
+  - predator: Lp
+    preference: 0.5
+    prey: Mf
+  - predator: Lp
+    preference: 1.0
+    prey: Mp
+  - predator: Lp
+    preference: 1.0
+    prey: Md
+  - predator: Ld
+    preference: 0.375
+    prey: Mf
+  - predator: Ld
+    preference: 0.75
+    prey: Mp
+  - predator: Ld
+    preference: 1.0
+    prey: Md
+  - predator: Ld
+    preference: 1.0
+    prey: benthic_prey
+loffline: true
+model_settings:
+  benthic_pelagic_depth_cutoff: 200.0
+  demersal_functional_type_keys:
+    - demersal
+    - benthic_prey
+  functional_type_keys:
+    - zooplankton
+    - forage
+    - piscivore
+    - demersal
+    - benthic_prey
+  pelagic_demersal_coupling_apply_pref_type_keys:
+    - demersal
+  pelagic_demersal_coupling_type_keys:
+    - piscivore
+    - demersal
+  pelagic_functional_type_keys:
+    - forage
+    - piscivore
+  size_class_bounds:
+    large:
+      - 250.0
+      - 125000.0
+    medium:
+      - 0.5
+      - 250.0
+    small:
+      - 0.001
+      - 0.5
+  zooplankton_functional_type_keys:
+    - zooplankton
+reproduction_routing:
+  - efficiency: 0.01
+    from: Mf
+    is_larval: true
+    to: Sf
+  - efficiency: 0.01
+    from: Lp
+    is_larval: true
+    to: Sp
+  - efficiency: 0.01
+    from: Ld
+    is_larval: true
+    to: Sd
+  - from: Sf
+    to: Mf
+  - from: Sp
+    to: Mp
+  - from: Sd
+    to: Md
+  - from: Mp
+    to: Lp
+  - from: Md
+    to: Ld
+zooplankton:
+  defaults: {}
+  members:
+    - name: Zoo

--- a/examples/feisty-settings.TL319_t13.4p2z.001.yml
+++ b/examples/feisty-settings.TL319_t13.4p2z.001.yml
@@ -1,0 +1,196 @@
+benthic_prey:
+  defaults:
+    benthic_efficiency: 0.075
+    carrying_capacity: 80.0
+  members:
+    - name: benthic_prey
+fish:
+  defaults:
+    a_consumption: 20.0
+    a_encounter: 70.0
+    a_metabolism: 4.0
+    assim_efficiency: 0.7
+    b_consumption: 0.25
+    b_encounter: 0.2
+    b_metabolism: 0.175
+    k_consumption: 0.063
+    k_encounter: 0.063
+    k_metabolism: 0.0855
+    mortality_coeff_per_yr: 0.1
+    mortality_type: constant
+  members:
+    - energy_frac_somatic_growth: 1.0
+      functional_type: forage
+      harvest_selectivity: 0.0
+      name: Sf
+      pelagic_demersal_coupling: false
+      size_class: small
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 1.0
+      functional_type: piscivore
+      harvest_selectivity: 0.0
+      name: Sp
+      pelagic_demersal_coupling: false
+      size_class: small
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 1.0
+      functional_type: demersal
+      harvest_selectivity: 0.0
+      name: Sd
+      pelagic_demersal_coupling: false
+      size_class: small
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 0.5
+      functional_type: forage
+      harvest_selectivity: 1.0
+      name: Mf
+      pelagic_demersal_coupling: false
+      size_class: medium
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 1.0
+      functional_type: piscivore
+      harvest_selectivity: 0.1
+      name: Mp
+      pelagic_demersal_coupling: false
+      size_class: medium
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 1.0
+      functional_type: demersal
+      harvest_selectivity: 0.1
+      name: Md
+      pelagic_demersal_coupling: false
+      size_class: medium
+      t_frac_pelagic_static: 0.0
+    - energy_frac_somatic_growth: 0.5
+      functional_type: piscivore
+      harvest_selectivity: 1.0
+      name: Lp
+      pelagic_demersal_coupling: false
+      size_class: large
+      t_frac_pelagic_static: 1.0
+    - energy_frac_somatic_growth: 0.5
+      functional_type: demersal
+      harvest_selectivity: 1.0
+      name: Ld
+      pelagic_demersal_coupling: true
+      size_class: large
+      t_frac_pelagic_static: 0.0
+fishing:
+  fishing_rate_per_year: 0.3
+food_web:
+  - predator: Sf
+    preference: 0.9
+    prey: Zoo
+  - predator: Sp
+    preference: 0.9
+    prey: Zoo
+  - predator: Sd
+    preference: 0.9
+    prey: Zoo
+  - predator: Mf
+    preference: 0.45
+    prey: Zoo
+  - predator: Mf
+    preference: 1.0
+    prey: Sf
+  - predator: Mf
+    preference: 1.0
+    prey: Sp
+  - predator: Mf
+    preference: 1.0
+    prey: Sd
+  - predator: Mp
+    preference: 0.45
+    prey: Zoo
+  - predator: Mp
+    preference: 1.0
+    prey: Sf
+  - predator: Mp
+    preference: 1.0
+    prey: Sp
+  - predator: Mp
+    preference: 1.0
+    prey: Sd
+  - predator: Md
+    preference: 1.0
+    prey: benthic_prey
+  - predator: Lp
+    preference: 0.5
+    prey: Mf
+  - predator: Lp
+    preference: 1.0
+    prey: Mp
+  - predator: Lp
+    preference: 1.0
+    prey: Md
+  - predator: Ld
+    preference: 0.375
+    prey: Mf
+  - predator: Ld
+    preference: 0.75
+    prey: Mp
+  - predator: Ld
+    preference: 1.0
+    prey: Md
+  - predator: Ld
+    preference: 1.0
+    prey: benthic_prey
+loffline: true
+model_settings:
+  benthic_pelagic_depth_cutoff: 200.0
+  demersal_functional_type_keys:
+    - demersal
+    - benthic_prey
+  functional_type_keys:
+    - zooplankton
+    - forage
+    - piscivore
+    - demersal
+    - benthic_prey
+  pelagic_demersal_coupling_apply_pref_type_keys:
+    - demersal
+  pelagic_demersal_coupling_type_keys:
+    - piscivore
+    - demersal
+  pelagic_functional_type_keys:
+    - forage
+    - piscivore
+  size_class_bounds:
+    large:
+      - 250.0
+      - 125000.0
+    medium:
+      - 0.5
+      - 250.0
+    small:
+      - 0.001
+      - 0.5
+  zooplankton_functional_type_keys:
+    - zooplankton
+reproduction_routing:
+  - efficiency: 0.01
+    from: Mf
+    is_larval: true
+    to: Sf
+  - efficiency: 0.01
+    from: Lp
+    is_larval: true
+    to: Sp
+  - efficiency: 0.01
+    from: Ld
+    is_larval: true
+    to: Sd
+  - from: Sf
+    to: Mf
+  - from: Sp
+    to: Mp
+  - from: Sd
+    to: Md
+  - from: Mp
+    to: Lp
+  - from: Md
+    to: Ld
+zooplankton:
+  defaults: {}
+  members:
+    - name: Zoo

--- a/examples/run-feisty-multiple-submissions.ipynb
+++ b/examples/run-feisty-multiple-submissions.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fcf68239-04f1-485f-bf25-cffa31b38d00",
+   "metadata": {},
+   "source": [
+    "# Notebook to demonstrate how to run FEISTY with multiple submissions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "efc5d15d-9313-4c1e-a29d-d7055c916b72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a21d9641-a0a5-494f-9dfc-475d5d98fdb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from glob import glob\n",
+    "from subprocess import check_call\n",
+    "\n",
+    "import FEISTY_driver\n",
+    "import matplotlib.pyplot as plt\n",
+    "import yaml\n",
+    "\n",
+    "import feisty"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4643fd9c-08b0-4b02-b96e-90893c8749c2",
+   "metadata": {},
+   "source": [
+    "## Specify case, setup info and forcing files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d3a9697e-48b8-4d2d-a26e-d38133639bca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# case = 'g.e22.TL319_t13.G1850ECOIAF_JRA_HR.4p2z.001'\n",
+    "# case_sname = 'TL319_t13.4p2z.001'\n",
+    "# dir_forcing = '/glade/scratch/kristenk/hi-res-feisty-inputs'\n",
+    "# nyears_per_submission = 1\n",
+    "\n",
+    "case = 'g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch'\n",
+    "case_sname = 'TL319_g17.4p2z.001'\n",
+    "dir_forcing = '/glade/work/mlevy/codes/feisty/input_files/1deg_companion_run'\n",
+    "nyears_per_submission = 1  # TODO: need better control here\n",
+    "\n",
+    "run_config_file = f'feisty-config.{case_sname}.yml'\n",
+    "run_forcing_file = f'feisty-forcing.{case_sname}.yml'\n",
+    "run_settings_file = f'feisty-settings.{case_sname}.yml'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e1058d5f-abd0-4eed-b5b3-dfc74efb8d67",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "computing_account: P93300670\n",
+      "diagnostic_names: []\n",
+      "forcing_rename:\n",
+      "  HT: bathymetry\n",
+      "  TEMP_BOTTOM: T_bottom\n",
+      "  TEMP_mean_100m: T_pelagic\n",
+      "  mesozooC_zint_100m_2: zooC\n",
+      "  mesozoo_loss_zint_100m: zoo_mort\n",
+      "  pocToFloor: poc_flux_bottom\n",
+      "  time: forcing_time\n",
+      "ignore_year_in_forcing: false\n",
+      "max_output_time_dim: 365\n",
+      "method: euler\n",
+      "num_chunks: 32\n",
+      "output_in_2D: true\n",
+      "resubmit: true\n",
+      "run_dir_root: /glade/scratch/{{env['USER']}}\n",
+      "run_name: feisty.TL319_g17.4p2z.001\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_config_info = dict(\n",
+    "    run_name=f\"feisty.{case_sname}\",\n",
+    "    num_chunks=32,\n",
+    "    ignore_year_in_forcing=False,\n",
+    "    diagnostic_names=[],\n",
+    "    max_output_time_dim=365,\n",
+    "    method=\"euler\",\n",
+    "    output_in_2D=True,\n",
+    "    computing_account=\"P93300670\",\n",
+    "    resubmit=True,\n",
+    "    run_dir_root=\"/glade/scratch/{{env['USER']}}\",\n",
+    "    forcing_rename={\n",
+    "        \"HT\": \"bathymetry\",\n",
+    "        \"time\": \"forcing_time\",\n",
+    "        \"pocToFloor\": \"poc_flux_bottom\",\n",
+    "        \"mesozooC_zint_100m_2\": \"zooC\",\n",
+    "        \"mesozoo_loss_zint_100m\": \"zoo_mort\",\n",
+    "        \"TEMP_BOTTOM\": \"T_bottom\",\n",
+    "        \"TEMP_mean_100m\": \"T_pelagic\",\n",
+    "    },\n",
+    ")\n",
+    "with open(run_config_file, 'w') as fid:\n",
+    "    yaml.dump(run_config_info, fid)\n",
+    "\n",
+    "check_call(['cat', run_config_file]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b3dd3b2a-a500-4614-84d2-9d4ba2f385e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "195801-196712:\n",
+      "  list_forcing_files:\n",
+      "  - /glade/work/mlevy/codes/feisty/input_files/1deg_companion_run/g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch.pop.h.TEMP_BOTTOM.195801-196712.nc\n",
+      "  - /glade/work/mlevy/codes/feisty/input_files/1deg_companion_run/g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch.pop.h.TEMP_mean_100m.195801-196712.nc\n",
+      "  - /glade/work/mlevy/codes/feisty/input_files/1deg_companion_run/g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch.pop.h.mesozooC_zint_100m_2.195801-196712.nc\n",
+      "  - /glade/work/mlevy/codes/feisty/input_files/1deg_companion_run/g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch.pop.h.mesozoo_loss_zint_100m.195801-196712.nc\n",
+      "  - /glade/work/mlevy/codes/feisty/input_files/1deg_companion_run/g.e22.GOMIPECOIAF_JRA-1p4-2018.TL319_g17.4p2z.001branch.pop.h.pocToFloor.195801-196712.nc\n",
+      "  nyears: 1\n",
+      "  start_date: '1958-01-01'\n",
+      "keys:\n",
+      "- 195801-196712\n"
+     ]
+    }
+   ],
+   "source": [
+    "forcing_files = sorted(glob(f'{dir_forcing}/{case}.pop.h.*.nc'))\n",
+    "datestrs = list({f.split('.')[-2] for f in forcing_files})\n",
+    "\n",
+    "required_vars = [\n",
+    "    'TEMP_BOTTOM',\n",
+    "    'TEMP_mean_100m',\n",
+    "    'mesozooC_zint_100m_2',\n",
+    "    'mesozoo_loss_zint_100m',\n",
+    "    'pocToFloor',\n",
+    "]\n",
+    "\n",
+    "forcing_file_groups = {k: {} for k in datestrs}\n",
+    "\n",
+    "for datestr in datestrs:\n",
+    "    file_list_i = [f for f in forcing_files if datestr in f]\n",
+    "    for v in required_vars:\n",
+    "        assert v in [f.split('.')[-3] for f in file_list_i]\n",
+    "\n",
+    "    forcing_file_groups[datestr]['list_forcing_files'] = file_list_i\n",
+    "    forcing_file_groups[datestr]['nyears'] = nyears_per_submission\n",
+    "    forcing_file_groups[datestr]['start_date'] = f'{datestr[:4]}-01-01'\n",
+    "\n",
+    "forcing_file_groups['keys'] = list(sorted(forcing_file_groups.keys()))\n",
+    "\n",
+    "with open(run_forcing_file, 'w') as fid:\n",
+    "    yaml.dump(forcing_file_groups, fid)\n",
+    "\n",
+    "check_call(['head', '-n', '20', run_forcing_file]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dd1aa11e-99da-48db-bb51-ae3d16c700b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['195801-196712']"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datestrs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7bc08512-4838-43a8-8a95-a2591b002d4a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "benthic_prey:\n",
+      "  defaults:\n",
+      "    benthic_efficiency: 0.075\n",
+      "    carrying_capacity: 80.0\n",
+      "  members:\n",
+      "  - name: benthic_prey\n",
+      "fish:\n",
+      "  defaults:\n",
+      "    a_consumption: 20.0\n",
+      "    a_encounter: 70.0\n",
+      "    a_metabolism: 4.0\n",
+      "    assim_efficiency: 0.7\n",
+      "    b_consumption: 0.25\n",
+      "    b_encounter: 0.2\n",
+      "    b_metabolism: 0.175\n",
+      "    k_consumption: 0.063\n",
+      "    k_encounter: 0.063\n",
+      "    k_metabolism: 0.0855\n",
+      "    mortality_coeff_per_yr: 0.1\n",
+      "    mortality_type: constant\n"
+     ]
+    }
+   ],
+   "source": [
+    "feisty_settings = feisty.settings.get_defaults()\n",
+    "with open(run_settings_file, 'w') as fid:\n",
+    "    yaml.dump(feisty_settings, fid)\n",
+    "\n",
+    "check_call(['head', '-n', '20', run_settings_file]);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e5be8cc-a42d-4216-97e1-02a1e94f137c",
+   "metadata": {},
+   "source": [
+    "## Run the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b36b0aa9-41f4-4164-8850-9c5bc87a8173",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "submitting run\n",
+      "qsub /glade/scratch/mclong/tmp/feisty-run.f6myapex.sh\n",
+      "4268950.casper-pbs\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "FEISTY_driver.submit_run(\n",
+    "    run_config_file,\n",
+    "    run_forcing_file,\n",
+    "    run_settings_file,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e1e706d-4b73-4634-9e2f-c51a5256f439",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:miniconda3-dev-feisty]",
+   "language": "python",
+   "name": "conda-env-miniconda3-dev-feisty-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/feisty/offline_driver.py
+++ b/feisty/offline_driver.py
@@ -630,6 +630,7 @@ def config_and_run_from_netcdf(
 
 def config_and_run_from_dataset(
     ds,
+    ds_ic,
     nstep,
     start_date='0001-01-01',
     ignore_year_in_forcing=False,
@@ -647,9 +648,12 @@ def config_and_run_from_dataset(
     domain_dict = dict()
     domain_dict['bathymetry'] = ds['bathymetry']
     domain_dict['NX'] = len(ds['X'])
+
     forcing = ds[['T_pelagic', 'T_bottom', 'poc_flux_bottom', 'zooC', 'zoo_mort']]
-    fish_ic_data = ds['fish_ic']
-    benthic_prey_ic_data = ds['bent_ic']
+
+    fish_ic_data = ds_ic['fish_ic']
+    benthic_prey_ic_data = ds_ic['bent_ic']
+
     feisty_driver = _offline_driver(
         domain_dict,
         forcing,
@@ -661,6 +665,8 @@ def config_and_run_from_dataset(
         diagnostic_names=diagnostic_names,
         max_output_time_dim=max_output_time_dim,
     )
+
     feisty_driver.run(nstep, method=method)
     feisty_driver.gen_ds()
+
     return feisty_driver.ds

--- a/feisty/utils/__init__.py
+++ b/feisty/utils/__init__.py
@@ -1,6 +1,7 @@
 from .cyclic_forcing import make_forcing_cyclic
 from .data_wrangling import (
     generate_1D_to_2D_pop_map,
+    generate_ic_ds_for_feisty,
     generate_single_ds_for_feisty,
     generate_template,
     map_ds_back_to_2D_pop,


### PR DESCRIPTION
This PR makes significant changes to `examples/FEISTY_driver.py` to support a queue-based simulation workflow.

The API to the FEISTY_driver CLI has changed; here is the context help:
```
Usage: FEISTY_driver.py [OPTIONS]

  Offline driver for FEISTY

Options:
  --run-config-file PATH    YAML file containing run settings  [required]
  --run-forcing-file PATH   YAML file containing forcing data  [required]
  --run-settings-file PATH  YAML file containing FEISTY model parameters
  --continue-run            flag to read initial conditions from restart file
  --help                    Show this message and exit.
```

I separated the config and forcing files. The forcing file has the following structure
```yaml
key1:
   list_forcing_files:
    - file1
    - file2
  nyears: 1
  start_date: '1964-01-01'
key2:
   list_forcing_files:
    - file1
    - file2
  nyears: 1
  start_date: '1965-01-01'
....
```
Each `key` corresponds to a queue submission. 

This needs additional work:
- we need to improve forcing indexing within `FEISTY_driver.main` to ensure were running the time period desired

If this was the case, we could probably do away with a level of hierarchy in the forcing file.

The model writes an `ic_file`, but I have not yet test restart ability.