### PR TITLE
Fix broken workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,9 +36,6 @@ jobs:
 
           fi
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
-      - name: Install pyyaml so mamba can pip install other packages
-        run: |
-          pip install pyyaml
       - name: Set up conda environment with micromamba
         uses: mamba-org/setup-micromamba@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,9 @@ jobs:
 
           fi
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
+      - name: Install pyyaml so mamba can pip install other packages
+        run: |
+          pip install pyyaml
       - name: Set up conda environment with micromamba
         uses: mamba-org/setup-micromamba@v2
         with:

--- a/.github/workflows/ci2.yaml
+++ b/.github/workflows/ci2.yaml
@@ -20,9 +20,6 @@ jobs:
       - uses: actions/checkout@v2
 
       # Install dependencies
-      - name: Install pyyaml so mamba can pip install other packages
-        run: |
-          pip install pyyaml
       - name: Set up conda environment with micromamba
         uses: mamba-org/setup-micromamba@v2
         with:

--- a/.github/workflows/ci2.yaml
+++ b/.github/workflows/ci2.yaml
@@ -20,6 +20,9 @@ jobs:
       - uses: actions/checkout@v2
 
       # Install dependencies
+      - name: Install pyyaml so mamba can pip install other packages
+        run: |
+          pip install pyyaml
       - name: Set up conda environment with micromamba
         uses: mamba-org/setup-micromamba@v2
         with:

--- a/.github/workflows/ci2.yaml
+++ b/.github/workflows/ci2.yaml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # python-version: [3.8]
     steps:
       - uses: actions/checkout@v2
 

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -26,10 +26,9 @@ dependencies:
   - pytest-cov
   - pyyaml
   - scipy
+  - sphinx-click
+  - spinxcontrib-autoyaml
   - xarray
   - zarr
   - pip:
-      - sphinx-click==6.0.0
-      - sphinxcontrib-autoyaml==1.1.3
-      - git+https://github.com/dask/dask-mpi.git@2022.4.0
       - '--editable=..'

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -31,5 +31,5 @@ dependencies:
   - pip:
       - sphinx-click==6.0.0
       - sphinxcontrib-autoyaml==1.1.3
-      - git+https://github.com/dask/dask-mpi.git==2022.4.0
+      - git+https://github.com/dask/dask-mpi.git@2022.4.0
       - '--editable=..'

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - pyyaml
   - scipy
   - sphinx-click
-  - spinxcontrib-autoyaml
+  - sphinxcontrib-autoyaml
   - xarray
   - zarr
   - pip:

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - xarray
   - zarr
   - pip:
-      - sphinx-click=6.0.0
-      - sphinxcontrib-autoyaml=1.1.3
-      - git+https://github.com/dask/dask-mpi.git=2022.4.0
+      - sphinx-click==6.0.0
+      - sphinxcontrib-autoyaml==1.1.3
+      - git+https://github.com/dask/dask-mpi.git==2022.4.0
       - '--editable=..'

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - pre-commit
   - pytest
   - pytest-cov
+  - pyyaml
   - scipy
   - xarray
   - zarr

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - pyyaml
   - scipy
   - sphinx-click
-  - sphinxcontrib-autoyaml
+  - sphinxcontrib-autoyaml==1.1.3
   - xarray
   - zarr
   - pip:

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - xarray
   - zarr
   - pip:
-      - sphinx-click
-      - sphinxcontrib-autoyaml
-      - git+https://github.com/dask/dask-mpi.git
+      - sphinx-click=6.0.0
+      - sphinxcontrib-autoyaml=1.1.3
+      - git+https://github.com/dask/dask-mpi.git=2022.4.0
       - '--editable=..'


### PR DESCRIPTION
Dropped testing from unsupported python versions (3.7 and 3.8, so we only test on 3.9 - 3.11 for now); also added pyyaml to dev-feisty environment since github actions were failing with

ModuleNotFoundError: No module named 'yaml'