### PR TITLE
Keep jupyterbook at version 1.X

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - dask-mpi
   - dask-jobqueue
   - jupyter
-  - jupyter-book
+  - jupyter-book<2
   - jupyter_client==6.1.12
   - jupyterlab
   - matplotlib


### PR DESCRIPTION
JupyterBook v2 is based on myst instead of sphinx, and seems to be breaking the feisty webpage generation workflow... this is a band-aid until we have time to update the documentation to work with the latest version.